### PR TITLE
support other gallery properties

### DIFF
--- a/packages/nast-util-to-react/src/components/Collection.tsx
+++ b/packages/nast-util-to-react/src/components/Collection.tsx
@@ -358,6 +358,12 @@ export function Gallery(props: CollectionProps) {
                       </div>
                     )
                   }
+                  case "checkbox":
+                  case "created_by":
+                  case "last_edited_by":
+                  case "created_time":
+                  case "last_edited_time":
+                      return <></> // An empty React.Fragment, which renders to nothing.
                   default:
                     // console.log(data.value)
                     return (

--- a/packages/nast-util-to-react/src/components/Collection.tsx
+++ b/packages/nast-util-to-react/src/components/Collection.tsx
@@ -363,7 +363,7 @@ export function Gallery(props: CollectionProps) {
                     return (
                       <div className={`${elemNameBase}Text`}>
                         <SemanticStringArray
-                          semanticStringArray={data.value} />
+                          semanticStringArray={data.value as NAST.SemanticString[]} />
                       </div>
                     )
                 }

--- a/packages/nast-util-to-react/test/theme.css
+++ b/packages/nast-util-to-react/test/theme.css
@@ -332,7 +332,7 @@ pre.Code code {
 
 .Gallery__Item__Cover {
   box-shadow: rgba(55, 53, 47, 0.09) 0px -1px 0px 0px inset;
-  height: 150px;
+  height: 200px;
 }
 
 .Gallery__Item__Cover>img {

--- a/packages/nast-util-to-react/test/theme.css
+++ b/packages/nast-util-to-react/test/theme.css
@@ -332,7 +332,7 @@ pre.Code code {
 
 .Gallery__Item__Cover {
   box-shadow: rgba(55, 53, 47, 0.09) 0px -1px 0px 0px inset;
-  height: 100%;
+  height: 150px;
 }
 
 .Gallery__Item__Cover>img {

--- a/packages/nast-util-to-react/test/theme.css
+++ b/packages/nast-util-to-react/test/theme.css
@@ -302,7 +302,7 @@ pre.Code code {
   transition: background 120ms ease-in 0s;
   position: relative;
   /* 10:7 */
-  padding-top: 70%;
+  /* padding-top: 70%; */
 }
 
 .Gallery__Item:hover {
@@ -314,7 +314,7 @@ pre.Code code {
   text-decoration: none;
 }
 
-.Gallery__Item>a>div {
+/* .Gallery__Item>a>div {
   position: absolute;
   top: 0;
   right: 0;
@@ -328,7 +328,7 @@ pre.Code code {
   /* grid-item-title has padding-top 8px, padding-bottom 10px, and its line-height.
      Since we can not get line-height with CSS, so just assign a large enough value. */
   height: calc(100% - 18px - 2rem);
-}
+} */
 
 .Gallery__Item__Cover {
   box-shadow: rgba(55, 53, 47, 0.09) 0px -1px 0px 0px inset;
@@ -337,7 +337,7 @@ pre.Code code {
 
 .Gallery__Item__Cover>img {
   width: 100%;
-  height: 100%;
+  max-height: 200px;
   border-radius: 5px 5px 0 0;
   object-fit: cover;
   object-position: center 50%;

--- a/packages/nast-util-to-react/test/theme.css
+++ b/packages/nast-util-to-react/test/theme.css
@@ -151,7 +151,7 @@ p {
 
 .Callout__Icon {
   width: 1.5em;
-  height: 1.5em;
+  line-height: 1.5;
 }
 
 .Callout__Content {
@@ -320,13 +320,13 @@ pre.Code code {
   right: 0;
   bottom: 0;
   left: 0;
-}
+} */
 
 /* This is the key to make the layout robust. */
 
-.Gallery__Item>a>div>div {
-  /* grid-item-title has padding-top 8px, padding-bottom 10px, and its line-height.
-     Since we can not get line-height with CSS, so just assign a large enough value. */
+/* .Gallery__Item>a>div>div {
+  grid-item-title has padding-top 8px, padding-bottom 10px, and its line-height.
+     Since we can not get line-height with CSS, so just assign a large enough value. 
   height: calc(100% - 18px - 2rem);
 } */
 
@@ -337,6 +337,7 @@ pre.Code code {
 
 .Gallery__Item__Cover>img {
   width: 100%;
+  height: 100%;
   max-height: 200px;
   border-radius: 5px 5px 0 0;
   object-fit: cover;
@@ -358,6 +359,20 @@ pre.Code code {
 
 .Gallery__Item__Title .SemanticString {
   white-space: nowrap;
+}
+
+.Gallery__Item__Select {
+  padding-top: 8px;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-bottom: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.Gallery__Item__Text {
+  padding: 6px 8px;
+  line-height: 1.5;
 }
 
 @supports not (display: grid) {


### PR DESCRIPTION
This PR supports other gallery properties such as tag and text. See the following for a demo

![image](https://user-images.githubusercontent.com/5555347/77812303-cadaa500-7076-11ea-8fe3-2f7546869085.png)

Had to mess with the CSS to make it not look like the following:

![image](https://user-images.githubusercontent.com/5555347/77812324-f52c6280-7076-11ea-864c-7b8565b86743.png)


Another behavior change is that, *instead of using the whole card as link to the notion page*, only the cover is linked to the notion page. Perhaps this behavior is not desirable with card that has no cover, but my ability is limited in making this general as I am sure I am misusing `visibleColumns.map(col => {... }`.