### PR TITLE
add go support

### DIFF
--- a/packages/nast-util-to-react/src/util-prismjs.ts
+++ b/packages/nast-util-to-react/src/util-prismjs.ts
@@ -177,6 +177,7 @@ const map: LangMap = {
   "Docker": "docker",
   "Elixir": "elixir",
   "Elm": "elm",
+  "Go": "go",
   "Java": "java"
 }
 


### PR DESCRIPTION
<img width="127" alt="image" src="https://user-images.githubusercontent.com/31946303/203043512-b718f465-bd64-40b0-9542-1d8f7bab7a32.png">

Hi, I want to add `go` language support，I have been check the keyword in `PrismJS` is **go**， and the keyword in `notion` is **Go**
 : )